### PR TITLE
fix: use SonarSource/sonarqube-scan-action instead of sonar-scanner

### DIFF
--- a/.github/workflows/generic-go-build.yaml
+++ b/.github/workflows/generic-go-build.yaml
@@ -214,26 +214,17 @@ jobs:
 
       - name: Upload coverage report to SonarCloud
         if: inputs.sonar-project-key != ''
-        working-directory: ${{ env.GO_MOD_DIR }}
+        uses: SonarSource/sonarqube-scan-action@v5
+        with:
+          projectBaseDir: ${{ env.GO_MOD_DIR }}
+          args: >
+            -Dproject.settings=sonar-project.properties
+            -Dsonar.projectKey=${{ inputs.sonar-project-key }}
+            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
+            -Dsonar.go.coverage.reportPaths=coverage.out
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: |
-          echo "::info:: Installing sonar-scanner..."
-          npm install -g sonar-scanner@3.1.0 --ignore-scripts
-
-          echo "::info:: Validating sonar-project.properties exists"
-          if [ ! -f "sonar-project.properties" ]; then
-            echo "::error:: sonar-project.properties not found in ${GO_MOD_DIR}"
-            exit 1
-          fi
-
-          echo "::info:: Running sonar-scanner..."
-          sonar-scanner \
-            -Dproject.settings=sonar-project.properties \
-            -Dsonar.projectKey=${{ inputs.sonar-project-key }} \
-            -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }} \
-            -Dsonar.host.url=${{ vars.SONAR_HOST_URL }} \
-            -Dsonar.go.coverage.reportPaths=coverage.out
+          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 
   docker-build:
     name: Build Docker image


### PR DESCRIPTION
## Why

Go repository builds fail on the Sonar step (#274). The workflow installs the
deprecated `sonar-scanner@3.1.0` globally via npm and runs it by hand, which no
longer works reliably.

## What

Replace the manual npm install and `sonar-scanner` invocation in
`generic-go-build.yaml` with the official `SonarSource/sonarqube-scan-action@v5`.
The same Sonar settings carry over:

- `projectBaseDir` set to `GO_MOD_DIR`
- project key, organization, and `sonar.go.coverage.reportPaths=coverage.out`
  passed through `args`
- `SONAR_HOST_URL` and `SONAR_TOKEN` moved to the step `env`

## How to verify

Run the Go build workflow with `sonar-project-key` set and confirm the
"Upload coverage report to SonarCloud" step completes and results appear in
SonarCloud.