### PR TITLE
chore(deps): bump 3rd-party dependencies for next release cycle

### DIFF
--- a/dependencies/quarkus-dependencies/pom.xml
+++ b/dependencies/quarkus-dependencies/pom.xml
@@ -15,7 +15,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <quarkus.version>3.33.2</quarkus.version>
+        <quarkus.version>3.33.3</quarkus.version>
         <jandex.version>3.5.3</jandex.version>
     </properties>
 

--- a/dependencies/spring-dependencies/pom.xml
+++ b/dependencies/spring-dependencies/pom.xml
@@ -16,8 +16,8 @@
 
     <properties>
         <!-- compatibility matrix - https://github.com/spring-cloud/spring-cloud-release/wiki/Supported-Versions#supported-releases-->
-        <spring.boot.version>4.0.6</spring.boot.version>
-        <spring-cloud.version>2025.1.1</spring-cloud.version>
+        <spring.boot.version>4.0.7</spring.boot.version>
+        <spring-cloud.version>2025.1.2</spring-cloud.version>
     </properties>
 
     <dependencyManagement>

--- a/renovate-core-config.json
+++ b/renovate-core-config.json
@@ -204,11 +204,11 @@
   }, {
     "matchPackageNames" : [ "io.quarkus.platform:quarkus-bom", "io.quarkus.platform:quarkus-maven-plugin", "io.quarkus.platform:quarkus-operator-sdk-bom" ],
     "groupName" : "maven",
-    "allowedVersions" : "/^3.33.1$/"
+    "allowedVersions" : "/^3.33.3$/"
   }, {
     "matchPackageNames" : [ "io.quarkus:quarkus-bom", "io.quarkus:quarkus-core", "io.quarkus:quarkus-core-deployment", "io.quarkus:quarkus-devtools-common", "io.quarkus:quarkus-extension-maven-plugin", "io.quarkus:quarkus-extension-processor", "io.quarkus:quarkus-maven-plugin", "io.quarkus:quarkus-rest-client", "io.quarkus:quarkus-universe-bom" ],
     "groupName" : "maven",
-    "allowedVersions" : "/^3.33.1$/"
+    "allowedVersions" : "/^3.33.3$/"
   }, {
     "matchPackageNames" : [ "io.opentelemetry.instrumentation:opentelemetry-kafka-clients-2.6" ],
     "groupName" : "maven",
@@ -236,7 +236,7 @@
   }, {
     "matchPackageNames" : [ "org.springframework.cloud:spring-cloud-dependencies" ],
     "groupName" : "maven",
-    "allowedVersions" : "/^2025.1.1$/"
+    "allowedVersions" : "/^2025.1.2$/"
   }, {
     "matchPackageNames" : [ "org.mockito:mockito-core", "org.mockito:mockito-junit-jupiter" ],
     "groupName" : "maven",
@@ -420,7 +420,7 @@
   }, {
     "matchPackageNames" : [ "org.springframework.boot:spring-boot", "org.springframework.boot:spring-boot-autoconfigure", "org.springframework.boot:spring-boot-dependencies", "org.springframework.boot:spring-boot-restclient", "org.springframework.boot:spring-boot-resttestclient", "org.springframework.boot:spring-boot-starter-actuator", "org.springframework.boot:spring-boot-starter-data-cassandra", "org.springframework.boot:spring-boot-starter-data-elasticsearch", "org.springframework.boot:spring-boot-starter-data-mongodb", "org.springframework.boot:spring-boot-starter-data-redis", "org.springframework.boot:spring-boot-starter-jdbc", "org.springframework.boot:spring-boot-starter-parent", "org.springframework.boot:spring-boot-starter-restclient-test", "org.springframework.boot:spring-boot-starter-security", "org.springframework.boot:spring-boot-starter-test", "org.springframework.boot:spring-boot-starter-web", "org.springframework.boot:spring-boot-starter-webflux", "org.springframework.boot:spring-boot-test", "org.springframework.boot:spring-boot-test-autoconfigure", "org.springframework.boot:spring-boot-webmvc-test" ],
     "groupName" : "maven",
-    "allowedVersions" : "/^4.0.6$/"
+    "allowedVersions" : "/^4.0.7$/"
   }, {
     "matchPackageNames" : [ "org.junit.jupiter:junit-jupiter", "org.junit.jupiter:junit-jupiter-api", "org.junit.jupiter:junit-jupiter-engine", "org.junit.jupiter:junit-jupiter-params" ],
     "groupName" : "maven",


### PR DESCRIPTION
# PR: Core Infra 3rd-Party Library Updates

## PR Summary
**Title:** chore(deps): bump 3rd-party dependencies for next release cycle
**Type:** Dependency Upgrade / Release Prep

### Problem Statement
The release process (`qubership-core-infra` step 1) requires upgrading core 3rd-party dependencies before cutting a new release. Outdated libraries pose potential security risks and deprive downstream microservices of performance and feature improvements.

### Root Cause
Regular release cycle progression requires baseline dependency bumps (Spring, Quarkus, etc.) to ensure long-term support and alignment with the open-source community.

### Solution Approach
- Bumped Spring Boot from `4.0.6` to `4.0.7` in `spring-dependencies/pom.xml`.
- Bumped Spring Cloud from `2025.1.1` to `2025.1.2` in `spring-dependencies/pom.xml`.
- Bumped Quarkus from `3.33.2` to `3.33.3` in `quarkus-dependencies/pom.xml`.
- Synchronized `renovate-core-config.json` regexes to allow auto-merging of these newly approved baseline versions to prevent Renovate from closing PRs.

---

## Changes Made

### Modified Files List
1. `dependencies/spring-dependencies/pom.xml`
2. `dependencies/quarkus-dependencies/pom.xml`
3. `renovate-core-config.json`

### Dependency Update Matrix

| Library Group | Current Version | Target Version |
|---------------|-----------------|----------------|
| Spring Boot   | 4.0.6           | 4.0.7          |
| Spring Cloud  | 2025.1.1        | 2025.1.2       |
| Quarkus BOM   | 3.33.1 / 3.33.2 | 3.33.3         |

---

## Validation Evidence

### Build Logs
- **Local Validation:** Due to an environment limitation (`mvn` not found locally), build compilation should be deferred to the GitHub Actions CI Pipeline (i.e. `generic-maven-build.yaml`).
- **Syntax Check:** Verified XML syntax in `pom.xml` files and validated `renovate-core-config.json` JSON structure.

### Security Scan Results
- Addressed through Renovate's existing vulnerability scanning (`vulnerabilityFixStrategy: lowest` active). The bumps represent stable patch updates, typically incorporating upstream CVE fixes.

---

## Risk Assessment

### Breaking Change Analysis
- **Impact:** LOW. The updates are strictly patch version increments (`4.0.x`, `3.33.x`), which semver guarantees to be backward-compatible bug fixes. 
- **Impacted Repositories:** All downstream `java libs`, `go libs`, `base images`, and `java services`.

### Rollback Strategy
If CI/CD downstream integration pipelines fail on `qubership-core-infra: released`, we will revert this PR using `git revert`, cut a hotfix release for `qubership-core-infra`, and rebuild downstream BOMs.

### Deployment Considerations
- Requires synchronous execution of Steps 3-18 in the Release Workflow (downstream service builds). Ensure CI runners are scaled properly as the BOM update will trigger rebuilds across all downstream repositories.
