### PR TITLE
feat: support monorepo in generic go build

### DIFF
--- a/.github/workflows/generic-go-build.yaml
+++ b/.github/workflows/generic-go-build.yaml
@@ -94,6 +94,9 @@ on:
         required: false
         type: string
         default: 'docker-dev-config.json'
+    secrets:
+      SONAR_TOKEN:
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/generic-go-build.yaml
+++ b/.github/workflows/generic-go-build.yaml
@@ -9,12 +9,13 @@
 #       with:
 #         sonar-project-key: ${{ vars.SONAR_PROJECT_KEY }}
 #         install-envtest: true  # for Kubernetes operators
+#         go-module-configs: '[{"dir":".","cover-packages":"./controllers/...,./api/..."},{"dir":"cmd/etcd-certs-to-secret","cover-packages":"./..."}]'
 #       secrets: inherit
 #
 # Features:
-#   - Automatic go.mod file detection (supports mono-repos with go-module-dir input)
+#   - Automatic go.mod discovery with multi-module mono-repo support
 #   - Go tests with coverage
-#   - SonarQube code quality and security scanning (optional)
+#   - SonarQube code quality and security scanning with aggregated coverage (optional)
 #   - Envtest support for Kubernetes operators (optional)
 #   - Automatic Docker image build (skipped if no config or for fork PRs)
 #
@@ -32,6 +33,10 @@ on:
       # Go module configuration
       go-module-dir:
         description: 'Optional directory containing go.mod file. If not specified, will search for go.mod files in the repository.'
+        required: false
+        type: string
+      go-module-configs:
+        description: 'Optional JSON array of module configs, for example [{"dir":".","cover-packages":"./controllers/...,./api/..."},{"dir":"cmd/etcd-certs-to-secret","cover-packages":"./..."}]. Takes precedence over go-module-dir and automatic discovery. The cover-packages is optional and defaults to "./...".'
         required: false
         type: string
 
@@ -100,9 +105,11 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test and analyze
+  discover:
+    name: Discover Go modules
     runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.discover.outputs.modules }}
     steps:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
@@ -110,63 +117,125 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
-      - name: Find go.mod files
-        id: find
+      - name: Discover go.mod files
+        id: discover
         shell: bash
         run: |
-          echo "::info:: Processing go.mod file location..."
+          set -euo pipefail
 
-          if [ -n "${{ inputs.go-module-dir }}" ]; then
-            # If go-module-dir is specified, only look in that directory
-            GO_MOD_DIR="${{ inputs.go-module-dir }}"
-            GO_MOD_FILE="${GO_MOD_DIR}/go.mod"
+          echo "::info:: Resolving Go module directories..."
 
-            if [ ! -d "$GO_MOD_DIR" ]; then
-              echo "::error:: Directory not found: ${GO_MOD_DIR}"
+          modules_json="[]"
+
+          add_module() {
+            local module_dir="$1"
+            local module_cover_packages="${2:-${{ inputs.cover-packages }}}"
+            local normalized_dir
+            local module_file
+            local module_name
+
+            normalized_dir="${module_dir#./}"
+            if [ -z "$normalized_dir" ]; then
+              normalized_dir="."
+            fi
+
+            module_file="${normalized_dir}/go.mod"
+            if [ "$normalized_dir" = "." ]; then
+              module_file="go.mod"
+            fi
+
+            if [ ! -d "$normalized_dir" ]; then
+              echo "::error:: Directory not found: ${normalized_dir}"
               exit 1
             fi
 
-            if [ ! -f "$GO_MOD_FILE" ]; then
-              echo "::error:: go.mod file not found in directory: ${GO_MOD_DIR}"
+            if [ ! -f "$module_file" ]; then
+              echo "::error:: go.mod file not found in directory: ${normalized_dir}"
               exit 1
             fi
 
-            echo "::info:: Using specified Go module directory: ${GO_MOD_DIR}"
+            module_name=$(echo "$normalized_dir" | tr '/.' '__' | tr -cd '[:alnum:]_-')
+            if [ -z "$module_name" ]; then
+              module_name="root"
+            fi
+
+            modules_json=$(
+              jq -c \
+                --arg dir "$normalized_dir" \
+                --arg name "$module_name" \
+                --arg cover_packages "$module_cover_packages" \
+                '. + [{"dir": $dir, "name": $name, "cover_packages": $cover_packages}]' \
+                <<<"$modules_json"
+            )
+          }
+
+          if [ -n "${{ inputs.go-module-configs }}" ]; then
+            echo "::info:: Using go-module-configs input..."
+            while IFS=$'\t' read -r module_dir module_cover_packages; do
+              add_module "$module_dir" "$module_cover_packages"
+            done < <(
+              jq -r --arg default_cover_packages '${{ inputs.cover-packages }}' '
+                if type != "array" then
+                  error("go-module-configs must be a JSON array")
+                else
+                  .[]
+                  | if (.dir // "") == "" then
+                      error("Each go-module-configs entry must contain non-empty dir")
+                    else
+                      [ .dir, (.["cover-packages"] // $default_cover_packages) ] | @tsv
+                    end
+                end
+              ' <<< '${{ inputs.go-module-configs }}'
+            )
+          elif [ -n "${{ inputs.go-module-dir }}" ]; then
+            echo "::info:: Using go-module-dir input..."
+            add_module "${{ inputs.go-module-dir }}"
           else
-            # Search for go.mod files in the repository
             echo "::info:: Searching for go.mod files..."
-            GO_MOD_FILES=$(find . -name go.mod)
-
-            if [ -z "$GO_MOD_FILES" ]; then
-              echo "::error:: No go.mod files found in the repository"
-              exit 1
-            fi
-
-            echo "::info:: Counting go.mod files..."
-            GO_MOD_COUNT=$(echo "$GO_MOD_FILES" | wc -l)
-            if [ "$GO_MOD_COUNT" -gt 1 ]; then
-              echo "::error:: Multiple go.mod files found. Please specify go-module-dir input parameter."
-              exit 1
-            fi
-
-            GO_MOD_FILE=$(echo "$GO_MOD_FILES" | head -n 1)
-            GO_MOD_DIR=$(dirname "${GO_MOD_FILE}")
-            echo "::info:: Using Go module at ${GO_MOD_DIR}"
+            while IFS= read -r module_file; do
+              [ -z "$module_file" ] && continue
+              add_module "$(dirname "${module_file}")"
+            done < <(find . -path '*/vendor/*' -prune -o -name go.mod -print | sort)
           fi
 
-          echo "GO_MOD_FILE=${GO_MOD_FILE}" >> "$GITHUB_ENV"
-          echo "GO_MOD_DIR=${GO_MOD_DIR}" >> "$GITHUB_ENV"
+          module_count=$(jq 'length' <<<"$modules_json")
+          if [ "$module_count" -eq 0 ]; then
+            echo "::error:: No go.mod files found in the repository"
+            exit 1
+          fi
+
+          echo "::info:: Found ${module_count} Go module(s)"
+          jq -r '.[] | "::info:: Module: \(.dir)"' <<<"$modules_json"
+
+          {
+            echo "modules=${modules_json}"
+          } >> "$GITHUB_OUTPUT"
+
+  test:
+    name: Test ${{ matrix.module.dir }}
+    needs: [discover]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        module: ${{ fromJson(needs.discover.outputs.modules) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
 
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
           cache: true
-          cache-dependency-path: "**/*.sum"
-          go-version-file: "${{ env.GO_MOD_FILE }}"
+          cache-dependency-path: ${{ matrix.module.dir }}/go.sum
+          go-version-file: ${{ matrix.module.dir }}/go.mod
 
       - name: Install envtest
         if: inputs.install-envtest == true
-        working-directory: ${{ env.GO_MOD_DIR }}
+        working-directory: ${{ matrix.module.dir }}
         env:
           ENVTEST_VERSION: ${{ inputs.envtest-version }}
           KUBE_VERSION: ${{ inputs.kube-version }}
@@ -197,9 +266,9 @@ jobs:
           echo "::info:: Setting up envtest for Kubernetes $KUBE_VERSION..."
           SETUP_OUTPUT=$(setup-envtest use "$KUBE_VERSION" -p env 2>&1)
           echo "$SETUP_OUTPUT"
-          ASSETS=$(echo "$SETUP_OUTPUT" | grep 'export KUBEBUILDER_ASSETS' | cut -d= -f2| tr -d "'\"")
+          ASSETS=$(echo "$SETUP_OUTPUT" | grep 'export KUBEBUILDER_ASSETS' | cut -d= -f2 | tr -d "'\"")
           if [ -d "$ASSETS" ]; then
-            echo "KUBEBUILDER_ASSETS=$ASSETS" >> $GITHUB_ENV
+            echo "KUBEBUILDER_ASSETS=$ASSETS" >> "$GITHUB_ENV"
             echo "::info:: Successfully set KUBEBUILDER_ASSETS=$ASSETS"
           else
             echo "::error:: envtest assets directory not found."
@@ -207,28 +276,80 @@ jobs:
           fi
 
       - name: Test with coverage
-        working-directory: ${{ env.GO_MOD_DIR }}
+        working-directory: ${{ matrix.module.dir }}
+        shell: bash
         run: |
+          set -euo pipefail
           echo "::info:: Running tests with coverage..."
-          go test -v ./... -coverpkg="${{ inputs.cover-packages }}" -coverprofile coverage.out
+          echo "::info:: Using cover packages: ${{ matrix.module.cover_packages }}"
+          go test -v ./... -coverpkg="${{ matrix.module.cover_packages }}" -coverprofile coverage.out
+
+      - name: Prepare coverage artifact
+        if: inputs.sonar-project-key != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p .sonar
+          cp "${{ matrix.module.dir }}/coverage.out" ".sonar/${{ matrix.module.name }}.coverage.out"
+
+      - name: Upload coverage artifact
+        if: inputs.sonar-project-key != ''
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
+        with:
+          name: coverage-${{ matrix.module.name }}
+          path: .sonar/${{ matrix.module.name }}.coverage.out
+          if-no-files-found: error
+
+  sonar:
+    name: Sonar analysis
+    if: inputs.sonar-project-key != ''
+    needs: [discover, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          ref: ${{ inputs.ref }}
+          fetch-depth: 0
+
+      - name: Download coverage artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5
+        with:
+          path: .sonar-artifacts
+          pattern: coverage-*
+          merge-multiple: true
+
+      - name: Resolve coverage paths
+        id: coverage
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          coverage_paths=$(find .sonar-artifacts -name '*.coverage.out' | sort | paste -sd, -)
+          if [ -z "$coverage_paths" ]; then
+            echo "::error:: No coverage artifacts found for Sonar analysis"
+            exit 1
+          fi
+
+          echo "::info:: Using coverage files: ${coverage_paths}"
+          echo "coverage_paths=${coverage_paths}" >> "$GITHUB_OUTPUT"
 
       - name: Upload coverage report to SonarCloud
-        if: inputs.sonar-project-key != ''
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         with:
-          projectBaseDir: ${{ env.GO_MOD_DIR }}
+          projectBaseDir: .
           args: >
             -Dproject.settings=sonar-project.properties
             -Dsonar.projectKey=${{ inputs.sonar-project-key }}
             -Dsonar.organization=${{ vars.SONAR_ORGANIZATION }}
-            -Dsonar.go.coverage.reportPaths=coverage.out
+            -Dsonar.go.coverage.reportPaths=${{ steps.coverage.outputs.coverage_paths }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 
   docker-build:
     name: Build Docker image
-    needs: [test]
+    needs: [test, sonar]
     # Skip docker build for PRs coming from forks or if skip-docker is true
     if: ${{ !inputs.skip-docker && !(github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork) }}
     uses: Netcracker/qubership-core-infra/.github/workflows/docker-build.yaml@afe90353c9a086f22355f99e14e24a06cfb5195b # v2.4.3

--- a/.github/workflows/generic-go-build.yaml
+++ b/.github/workflows/generic-go-build.yaml
@@ -312,15 +312,50 @@ jobs:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
 
+      - name: Resolve Sonar project configuration
+        id: resolve
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          modules_json='${{ needs.discover.outputs.modules }}'
+
+          if [ -f "sonar-project.properties" ]; then
+            echo "::info:: Using repository-level sonar-project.properties"
+            {
+              echo "project_base_dir=."
+              echo "coverage_dir=.sonar-artifacts"
+            } >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          module_count=$(jq 'length' <<<"$modules_json")
+          if [ "$module_count" = "1" ]; then
+            module_dir=$(jq -r '.[0].dir' <<<"$modules_json")
+            if [ -f "${module_dir}/sonar-project.properties" ]; then
+              echo "::info:: Using module-level sonar-project.properties from ${module_dir}"
+              {
+                echo "project_base_dir=${module_dir}"
+                echo "coverage_dir=${module_dir}/.sonar-artifacts"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "::error:: sonar-project.properties not found in repository root"
+          echo "::error:: For single-module repositories it may also be placed in the module directory"
+          exit 1
+
       - name: Download coverage artifacts
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v5
         with:
-          path: .sonar-artifacts
+          path: ${{ steps.resolve.outputs.coverage_dir }}
           pattern: coverage-*
           merge-multiple: true
 
       - name: Resolve coverage paths
         id: coverage
+        working-directory: ${{ steps.resolve.outputs.project_base_dir }}
         shell: bash
         run: |
           set -euo pipefail
@@ -337,7 +372,7 @@ jobs:
       - name: Upload coverage report to SonarCloud
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6
         with:
-          projectBaseDir: .
+          projectBaseDir: ${{ steps.resolve.outputs.project_base_dir }}
           args: >
             -Dproject.settings=sonar-project.properties
             -Dsonar.projectKey=${{ inputs.sonar-project-key }}


### PR DESCRIPTION
**What changed**

- Added Go module discovery step for repositories with multiple go.mod files.
- Added go-module-configs input to allow explicit per-module configuration.
- Switched test execution to a matrix over discovered modules.
- Added per-module cover-packages support.
- Aggregated coverage artifacts from all modules for Sonar.
- Kept compatibility for single-module repositories, including the case when the module and sonar-project.properties are located in a subdirectory.
- Declared SONAR_TOKEN in workflow_call.secrets so reusable workflow calls can pass it explicitly.

**Sonar behavior**

- If `sonar-project.properties` exists in the repository root, Sonar runs from the repository root and uses aggregated coverage from all modules.
- If the repository has a single Go module and sonar-project.properties is located inside that module directory, Sonar runs from that module directory.
- Multi-module repositories are expected to use a root-level sonar-project.properties.